### PR TITLE
Changed MariaDB to MySQL 

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM mysql:5.6
 
 ENV MYSQL_ROOT_PASSWORD=eSaudeRootMySQLPassword
 ENV MYSQL_DATABASE=openmrs
@@ -10,13 +10,15 @@ ADD esaude-mysql.cnf /root/.my.cnf
 ADD backup /usr/bin/backup
 ADD localtime /etc/localtime
 
-RUN apk add --update mariadb mariadb-client curl zip unzip; \
-    curl -L https://bintray.com/artifact/download/esaude/platform/esaude-platform-database-1.2.1.sql.zip \
-         -o /tmp/esaude-platform-database.sql.zip; \
-    apk del curl unzip && rm -f /var/cache/apk/*; \
-    rm /usr/bin/mysql_client_test_embedded; \
-    rm /usr/bin/mysqltest; \
-    rm /usr/bin/mysqltest_embedded;
+RUN apt-get update && apt-get install -y \
+    curl \
+    zip \
+    unzip \
+&& curl -L https://bintray.com/artifact/download/esaude/platform/esaude-platform-database-1.2.1.sql.zip \
+    -o /tmp/esaude-platform-database.sql.zip \
+&& apt-get remove -y \
+   curl \
+   zip  
 
 COPY run.sh /run.sh
 

--- a/mysql/run.sh
+++ b/mysql/run.sh
@@ -30,7 +30,7 @@ else
 		GRANT ALL ON \`$MYSQL_DATABASE\`.* to '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD';
 	EOF
 
-  /usr/bin/mysqld --user=root --bootstrap --verbose=0 < "$tfile"
+  /usr/sbin/mysqld --user=root --bootstrap --verbose=0 < "$tfile"
   rm -f "$tfile"
 
 	cd tmp
@@ -40,4 +40,4 @@ else
 fi
 
 echo 'Starting server'
-exec /usr/bin/mysqld --user=root --console
+exec /usr/sbin/mysqld --user=root --console


### PR DESCRIPTION
For now MySQL will be used instead of MariaDB for report performance reasons. It was observed that some reports(SAPR/APR ARV, SAPR/APR CLC) running on MariaDB take more that 6 hours to be generated(ARIEL claim 24h), while in MySQL we are able to generate them in a matter of 6/7 minutes. 
Now the eSaude Mysql image is based on the standard Mysql image instead of alpine(with MariaDB installed on it)