### PR TITLE
Patch message properties files in openmrs.war file before docker build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 services:
 - docker
 before_script:
-  - sed -i "s/__RELEASE_VERSION__/$TRAVIS_TAG/g" tomcat/Dockerfile
+  - if [ -z $TRAVIS_TAG ]; then sed -i "s/__RELEASE_VERSION__/$TRAVIS_COMMIT/g" tomcat/Dockerfile; else sed -i "s/__RELEASE_VERSION__/$TRAVIS_TAG/g" tomcat/Dockerfile; fi
 script:
   - docker-compose build
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: required
 services:
 - docker
+before_script:
+  - sed -i "s/__RELEASE_VERSION__/$TRAVIS_TAG/g" tomcat/Dockerfile
 script:
   - docker-compose build
 after_script:

--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -1,5 +1,6 @@
 FROM tomcat:7-jre7-alpine
 
+ENV RELEASE_VERSION __RELEASE_VERSION__
 ENV DOCKERIZE_VERSION v0.2.0
 
 ADD openmrs-runtime.properties /usr/local/tomcat/openmrs-runtime.properties
@@ -9,10 +10,23 @@ ADD localtime /etc/localtime
 ADD logging.properties /usr/local/tomcat/conf/logging.properties
 ADD catalina.properties /usr/local/tomcat/conf/catalina.properties
 
-RUN apk --update add curl unzip; \
+RUN apk --update add curl unzip fastjar; \
     rm -rf /usr/local/tomcat/webapps/*; \
     curl -k -L https://bintray.com/artifact/download/esaude/platform/1.2.0/openmrs.war \
-         -o /usr/local/tomcat/webapps/openmrs.war;
+         -o /usr/local/tomcat/webapps/openmrs.war; \
+    mkdir /tmp/war_temp && unzip -q /usr/local/tomcat/webapps/openmrs.war -d /tmp/war_temp; \
+    sed -i "s/Powered by/Powered by eSaúde Platform v$RELEASE_VERSION and/g" /tmp/war_temp/WEB-INF/messages.properties; \
+    sed -i "s/Desarrollado por/Desarrollado por eSaúde Plataforma v$RELEASE_VERSION y/g" /tmp/war_temp/WEB-INF/messages_es.properties; \
+    sed -i "s/Powered by/Powered by eSaúde Platform v$RELEASE_VERSION and/g" /tmp/war_temp/WEB-INF/messages_fa.properties; \
+    sed -i "s/poweredBy=OpenMRS/poweredBy=eSaúde Platform v$RELEASE_VERSION and OpenMRS/g" /tmp/war_temp/WEB-INF/messages_hi.properties; \
+    sed -i "s/Diberdayakan oleh/Diberdayakan oleh eSaúde Platform v$RELEASE_VERSION dan/g" /tmp/war_temp/WEB-INF/messages_in_ID.properties; \
+    sed -i "s/Fornecido Por/Fornecido Por eSaúde Plataforma v$RELEASE_VERSION e/g" /tmp/war_temp/WEB-INF/messages_pt.properties; \
+    sed -i "s/Powered by/Powered by eSaúde Platform v$RELEASE_VERSION and/g" /tmp/war_temp/WEB-INF/messages_ru.properties; \
+    sed -i "s/poweredBy=OpenMRS/poweredBy=eSaúde Platform v$RELEASE_VERSION සහ/g" /tmp/war_temp/WEB-INF/messages_si.properties; \
+    sed -i "s/技术OpenMRS/技术 eSaúde Platform v$RELEASE_VERSION 和 OpenMRS/g" /tmp/war_temp/WEB-INF/messages_zh_CN.properties; \
+    cd /tmp/war_temp && fastjar cf /tmp/openmrs-patched.war -M *; \
+    mv -f /tmp/openmrs-patched.war /usr/local/tomcat/webapps/openmrs.war; \
+    rm -rf /tmp/war_temp;
 
 RUN mkdir -p /usr/local/tomcat/.OpenMRS/modules; \
     curl -k -L https://bintray.com/artifact/download/esaude/platform/esaude-platform-modules-1.6.4.zip \
@@ -23,7 +37,7 @@ RUN mkdir -p /usr/local/tomcat/.OpenMRS/modules; \
          -o /tmp/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz; \
     tar -C /usr/local/bin -xzvf /tmp/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz; \
     rm /tmp/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz; \
-    apk del curl unzip && rm -f /var/cache/apk/*;
+    apk del curl unzip fastjar && rm -f /var/cache/apk/*;
 
 VOLUME /opt/esaude/data
 


### PR DESCRIPTION
This is the easiest way to customize the 'Powered by' text in the footer of the OpenMRS UI to add the eSaude platform version number.  The recommended way to do this would normally be to create custom messages properties and reference them in the runtime properties file.  However, in these older versions of OpenMRS (and I think still in the 2.x versions), the only 4 languages that can be overridden with custom files are English, French, Spanish and German.  All others are ignored.

This will pull the tag name from a tagged release and use that as version number to patch all of the messages properties files that have a 'poweredBy' key defined (as of version 1.11.5).