### PR TITLE
Removed the option to remove the the package zip with apk.

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -17,8 +17,7 @@ RUN apt-get update && apt-get install -y \
 && curl -L https://bintray.com/artifact/download/esaude/platform/esaude-platform-database-1.2.1.sql.zip \
     -o /tmp/esaude-platform-database.sql.zip \
 && apt-get remove -y \
-   curl \
-   zip  
+   curl 
 
 COPY run.sh /run.sh
 


### PR DESCRIPTION
Removing the zip from the image cause the backup script to fail, as it needs zip to archive the database.